### PR TITLE
Fix queue service import for socket events

### DIFF
--- a/partyqueue/sockets/events.py
+++ b/partyqueue/sockets/events.py
@@ -1,6 +1,5 @@
 from flask_socketio import join_room, leave_room, emit
-from . import queue_service
-from ..services import vote_service
+from ..services import queue_service, vote_service
 
 # in-memory store for demo
 _queues = {}


### PR DESCRIPTION
## Summary
- fix missing import for queue service in socket events

## Testing
- `make lint` *(fails: E501 line too long, etc.)*
- `make test`
- `make dev` *(fails: ImportError: cannot import name 'url_decode' from 'werkzeug.urls')*

------
https://chatgpt.com/codex/tasks/task_e_68c5e0e275808327b48752a6540a5e41