### PR TITLE
Fix Mongo URI configuration mismatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 FLASK_ENV=development
 SECRET_KEY=changeme
-MONGODB_URI=mongodb://mongo:27017/partyqueue
+MONGO_URI=mongodb://mongo:27017/partyqueue
 YOUTUBE_API_KEY=your_youtube_key_here

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ cp .env.example .env
 
 - `FLASK_ENV` – development or production mode
 - `SECRET_KEY` – random string used by Flask for session security
-- `MONGODB_URI` – connection string for MongoDB (e.g. `mongodb://localhost:27017/partyqueue`)
+- `MONGO_URI` – connection string for MongoDB (e.g. `mongodb://localhost:27017/partyqueue`)
+  (`MONGODB_URI` is also accepted)
 - `YOUTUBE_API_KEY` – API key for the YouTube Data API v3
 
 To obtain a YouTube API key:
@@ -83,7 +84,8 @@ sudo systemctl start mongod
 ```
 
 The application expects MongoDB at `mongodb://localhost:27017/partyqueue` by
-default. You can change this by setting `MONGODB_URI` in `.env`.
+default. You can change this by setting `MONGO_URI` in `.env` (or
+`MONGODB_URI`).
 
 If you prefer to run the entire stack in Docker, you can run:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - FLASK_APP=partyqueue.app
       - FLASK_ENV=development
-      - MONGODB_URI=mongodb://mongo:27017/partyqueue
+      - MONGO_URI=mongodb://mongo:27017/partyqueue
       - SECRET_KEY=changeme
       - YOUTUBE_API_KEY=your_youtube_key_here
   mongo:

--- a/partyqueue/config.py
+++ b/partyqueue/config.py
@@ -4,7 +4,9 @@ from datetime import timedelta
 
 class Config:
     SECRET_KEY = os.getenv("SECRET_KEY", "dev")
-    MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017/partyqueue")
+    MONGO_URI = os.getenv("MONGO_URI") or os.getenv(
+        "MONGODB_URI", "mongodb://localhost:27017/partyqueue"
+    )
     SESSION_COOKIE_SECURE = False
     REMEMBER_COOKIE_DURATION = timedelta(days=7)
     SUGGEST_COOLDOWN_SEC = int(os.getenv("SUGGEST_COOLDOWN_SEC", "20"))


### PR DESCRIPTION
## Summary
- configure Flask-PyMongo using `MONGO_URI` with fallback to `MONGODB_URI`
- update example environment, Docker Compose and documentation to match

## Testing
- `make lint` *(fails: partyqueue/models/rooms.py:3:1: F811 redefinition of unused 'datetime' from line 1, etc.)*
- `make test`
- `make dev` *(fails: ImportError: cannot import name 'url_decode' from 'werkzeug.urls')*

------
https://chatgpt.com/codex/tasks/task_e_68c5e25586048327b616cb65f659db67