### PR TITLE
Fix user session loading for authenticated routes

### DIFF
--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,0 +1,27 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from bson import ObjectId
+from partyqueue.services import auth_service
+from partyqueue.extensions import mongo
+from partyqueue.models import USERS_COLL
+
+
+class DummyCollection:
+    def __init__(self, doc):
+        self._doc = doc
+
+    def find_one(self, query):
+        # simulate MongoDB lookup by _id
+        return self._doc if query.get("_id") == self._doc["_id"] else None
+
+
+def test_load_user_converts_objectid(monkeypatch):
+    user_doc = {"_id": ObjectId(), "email": "e@example.com", "username": "e"}
+    dummy_db = {USERS_COLL: DummyCollection(user_doc)}
+    # replace the mongo.db with our dummy mapping
+    monkeypatch.setattr(mongo, "db", dummy_db, raising=False)
+
+    loaded = auth_service.load_user(str(user_doc["_id"]))
+    assert loaded is not None
+    assert loaded.id == str(user_doc["_id"])


### PR DESCRIPTION
## Summary
- Convert stored user id back to `ObjectId` when loading sessions
- Add regression test covering `load_user`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5fe41e21c8327b8429dfc8dba4a87