### PR TITLE
Add room creation UI and logout button

### DIFF
--- a/partyqueue/templates/base.html
+++ b/partyqueue/templates/base.html
@@ -15,7 +15,10 @@
         <a href="{{ url_for('rooms.landing') }}" class="font-bold">PartyQueue</a>
         <div>
           {% if current_user.is_authenticated %}
-          <span>{{ current_user.username }}</span>
+          <span class="mr-4">{{ current_user.username }}</span>
+          <form action="{{ url_for('auth.logout') }}" method="post" class="inline">
+            <button type="submit" class="text-blue-600">Logout</button>
+          </form>
           {% else %}
           <a href="{{ url_for('auth.signup') }}" class="mr-4 text-blue-600">Sign up</a>
           <a href="{{ url_for('auth.login') }}" class="text-blue-600">Login</a>

--- a/partyqueue/templates/host_room.html
+++ b/partyqueue/templates/host_room.html
@@ -1,9 +1,20 @@
 {% extends 'base.html' %}
 {% block title %}Host Room{% endblock %}
 {% block content %}
-<h1 class="text-xl">Host Room</h1>
+{% if room %}
+<h1 class="text-xl">Host Room: {{ room.name }}</h1>
+<p class="mb-2">Listener code: {{ room.code_listener }}</p>
+<p class="mb-4">Suggestor code: {{ room.code_suggestor }}</p>
 <div id="player" class="my-4"></div>
 <ul id="queue"></ul>
 <script src="https://www.youtube.com/iframe_api"></script>
+<script>window.roomId = "{{ room._id }}";</script>
 <script src="/static/js/host_player.js" defer></script>
+{% else %}
+<h1 class="text-xl mb-4">Create Room</h1>
+<form method="post" class="flex flex-col gap-2">
+  <input type="text" name="name" placeholder="Room Name" class="border p-2" />
+  <button class="bg-blue-500 text-white p-2" type="submit">Create</button>
+</form>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Allow hosts to create rooms with a name and view listener/suggestor codes
- Show a logout button in the navigation bar for authenticated users

## Testing
- `pytest`
- `flake8 partyqueue tests` *(fails: F811 redefinition of unused 'datetime' from line 1, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c60009bf788327b262a651079e1c37