### PR TITLE
Handle POST join requests for room codes

### DIFF
--- a/partyqueue/routes/rooms.py
+++ b/partyqueue/routes/rooms.py
@@ -34,7 +34,12 @@ def guest(room_id):
     room = mongo.db[ROOMS_COLL].find_one({"_id": room_id})
     return render_template("guest_room.html", room=room)
 
-
-@rooms_bp.route("/join")
+@rooms_bp.route("/join", methods=["GET", "POST"])
 def join_page():
+    if request.method == "POST":
+        code = request.form.get("code", "").strip().upper()
+        room = room_model.find_by_code(mongo.db[ROOMS_COLL], code)
+        if room:
+            return redirect(url_for("rooms.guest", room_id=room["_id"]))
+        return render_template("join_room.html", error="Invalid code")
     return render_template("join_room.html")

--- a/partyqueue/templates/join_room.html
+++ b/partyqueue/templates/join_room.html
@@ -2,6 +2,9 @@
 {% block title %}Join Room{% endblock %}
 {% block content %}
 <h1 class="text-xl">Join Room</h1>
+{% if error %}
+<p class="text-red-500 mb-2">{{ error }}</p>
+{% endif %}
 <form method="post" class="flex gap-2">
   <input type="text" name="code" placeholder="Enter Code" class="border p-2" />
   <button class="bg-blue-500 text-white p-2" type="submit">Join</button>


### PR DESCRIPTION
## Summary
- Support POST submissions on `/join` by looking up the provided code and redirecting to the guest room or showing an error
- Display error message on the join page when an invalid code is entered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6037cd97c83278f70389ed7c4cbb5