### PR TITLE
Use timezone-aware timestamps

### DIFF
--- a/partyqueue/models/chats.py
+++ b/partyqueue/models/chats.py
@@ -1,16 +1,17 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from . import ObjectId
 
 
-def insert_message(coll, room_id: str, sender_id: str | None,
-                   sender_name: str, message: str) -> str:
+def insert_message(
+    coll, room_id: str, sender_id: str | None, sender_name: str, message: str
+) -> str:
     doc = {
         "_id": ObjectId(),
         "room_id": room_id,
         "sender_id": sender_id,
         "sender_name": sender_name,
         "message": message,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(timezone.utc),
     }
     coll.insert_one(doc)
     return doc["_id"]

--- a/partyqueue/models/rooms.py
+++ b/partyqueue/models/rooms.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-import random
-from datetime import datetime
+from datetime import datetime, timezone
 import random
 import string
 from . import ObjectId
@@ -20,7 +18,7 @@ def create_room(coll, name: str, host_user_id: str) -> dict:
         "code_listener": _generate_code("L"),
         "code_suggestor": _generate_code("S"),
         "active": True,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(timezone.utc),
         "deleted_video_ids": [],
         "banned_video_ids": [],
         "current_song_id": None,

--- a/partyqueue/models/songs.py
+++ b/partyqueue/models/songs.py
@@ -1,10 +1,17 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from . import ObjectId
 
 
-def insert_song(coll, room_id: str, video_id: str, title: str,
-                thumbnail_url: str, duration_sec: int, added_by_user_id: str | None,
-                added_by_display_name: str) -> dict:
+def insert_song(
+    coll,
+    room_id: str,
+    video_id: str,
+    title: str,
+    thumbnail_url: str,
+    duration_sec: int,
+    added_by_user_id: str | None,
+    added_by_display_name: str,
+) -> dict:
     song = {
         "_id": ObjectId(),
         "room_id": room_id,
@@ -14,7 +21,7 @@ def insert_song(coll, room_id: str, video_id: str, title: str,
         "duration_sec": duration_sec,
         "added_by_user_id": added_by_user_id,
         "added_by_display_name": added_by_display_name,
-        "added_at": datetime.utcnow(),
+        "added_at": datetime.now(timezone.utc),
         "likes": [],
         "dislikes": [],
         "score": 0,
@@ -27,4 +34,8 @@ def insert_song(coll, room_id: str, video_id: str, title: str,
 
 
 def get_queue(coll, room_id: str) -> list[dict]:
-    return list(coll.find({"room_id": room_id, "played": False, "removed_by_host": False}))
+    return list(
+        coll.find(
+            {"room_id": room_id, "played": False, "removed_by_host": False}
+        )
+    )

--- a/partyqueue/models/users.py
+++ b/partyqueue/models/users.py
@@ -1,14 +1,16 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from werkzeug.security import generate_password_hash, check_password_hash
 from pymongo.collection import Collection
 
 
-def create_user(coll: Collection, email: str, username: str, password: str) -> str:
+def create_user(
+    coll: Collection, email: str, username: str, password: str
+) -> str:
     doc = {
         "email": email,
         "username": username,
         "password_hash": generate_password_hash(password),
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(timezone.utc),
         "current_rooms_owned": [],
     }
     result = coll.insert_one(doc)

--- a/partyqueue/services/queue_service.py
+++ b/partyqueue/services/queue_service.py
@@ -1,20 +1,25 @@
 from typing import List
 from ..models import ObjectId
-from datetime import datetime
+from datetime import datetime, timezone
 from . import room_service
 
 
 class QueueService:
     @staticmethod
     def add_song(room: dict, queue: List[dict], song: dict) -> dict | None:
-        """Add song if allowed and not duplicate. Returns existing or new song."""
+        """Add song if allowed and not duplicate.
+        Returns existing or new song."""
         if not room_service.is_video_allowed(room, song["video_id"]):
             return None
         for existing in queue:
-            if existing["video_id"] == song["video_id"] and not existing.get("removed_by_host") and not existing.get("played"):
+            if (
+                existing["video_id"] == song["video_id"]
+                and not existing.get("removed_by_host")
+                and not existing.get("played")
+            ):
                 return existing
         song.setdefault("_id", ObjectId())
-        song.setdefault("added_at", datetime.utcnow())
+        song.setdefault("added_at", datetime.now(timezone.utc))
         song.setdefault("likes", [])
         song.setdefault("dislikes", [])
         song.setdefault("score", 0)
@@ -33,7 +38,11 @@ class QueueService:
     @staticmethod
     def order_queue(queue: List[dict]) -> List[dict]:
         return sorted(
-            [s for s in queue if not s.get("removed_by_host") and not s.get("played")],
+            [
+                s
+                for s in queue
+                if not s.get("removed_by_host") and not s.get("played")
+            ],
             key=lambda s: (-s.get("score", 0), s["added_at"]),
         )
 

--- a/partyqueue/services/room_service.py
+++ b/partyqueue/services/room_service.py
@@ -1,8 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def is_video_allowed(room: dict, video_id: str) -> bool:
-    return video_id not in room.get("banned_video_ids", []) and video_id not in room.get("deleted_video_ids", [])
+    return video_id not in room.get(
+        "banned_video_ids", []
+    ) and video_id not in room.get("deleted_video_ids", [])
 
 
 def ban_video(room: dict, video_id: str) -> None:
@@ -11,10 +13,12 @@ def ban_video(room: dict, video_id: str) -> None:
 
 
 def unban_video(room: dict, video_id: str) -> None:
-    room["banned_video_ids"] = [v for v in room.get("banned_video_ids", []) if v != video_id]
+    room["banned_video_ids"] = [
+        v for v in room.get("banned_video_ids", []) if v != video_id
+    ]
 
 
 def mark_deleted(room: dict, song: dict) -> None:
     room.setdefault("deleted_video_ids", []).append(song["video_id"])
     song["removed_by_host"] = True
-    song["removed_at"] = datetime.utcnow()
+    song["removed_at"] = datetime.now(timezone.utc)

--- a/tests/test_queue_logic.py
+++ b/tests/test_queue_logic.py
@@ -1,7 +1,5 @@
-import sys, os
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from datetime import datetime, timedelta, timezone
 
-from datetime import datetime, timedelta
 from partyqueue.services.queue_service import QueueService
 from partyqueue.services.vote_service import VoteService
 
@@ -9,10 +7,28 @@ from partyqueue.services.vote_service import VoteService
 def test_queue_ordering():
     room = {"banned_video_ids": [], "deleted_video_ids": []}
     queue = []
-    now = datetime.utcnow()
-    s1 = QueueService.add_song(room, queue, {"video_id": "a", "title": "A", "added_at": now})
-    s2 = QueueService.add_song(room, queue, {"video_id": "b", "title": "B", "added_at": now + timedelta(seconds=1)})
-    s3 = QueueService.add_song(room, queue, {"video_id": "c", "title": "C", "added_at": now + timedelta(seconds=2)})
+    now = datetime.now(timezone.utc)
+    s1 = QueueService.add_song(
+        room, queue, {"video_id": "a", "title": "A", "added_at": now}
+    )
+    s2 = QueueService.add_song(
+        room,
+        queue,
+        {
+            "video_id": "b",
+            "title": "B",
+            "added_at": now + timedelta(seconds=1),
+        },
+    )
+    s3 = QueueService.add_song(
+        room,
+        queue,
+        {
+            "video_id": "c",
+            "title": "C",
+            "added_at": now + timedelta(seconds=2),
+        },
+    )
 
     VoteService.vote(s1, "u1", "like")
     VoteService.vote(s2, "u2", "like")
@@ -26,11 +42,25 @@ def test_queue_ordering():
 
 
 def test_auto_advance():
-    room = {"banned_video_ids": [], "deleted_video_ids": [], "current_song_id": None}
+    room = {
+        "banned_video_ids": [],
+        "deleted_video_ids": [],
+        "current_song_id": None,
+    }
     queue = []
-    now = datetime.utcnow()
-    s1 = QueueService.add_song(room, queue, {"video_id": "a", "title": "A", "added_at": now})
-    s2 = QueueService.add_song(room, queue, {"video_id": "b", "title": "B", "added_at": now + timedelta(seconds=1)})
+    now = datetime.now(timezone.utc)
+    s1 = QueueService.add_song(
+        room, queue, {"video_id": "a", "title": "A", "added_at": now}
+    )
+    s2 = QueueService.add_song(
+        room,
+        queue,
+        {
+            "video_id": "b",
+            "title": "B",
+            "added_at": now + timedelta(seconds=1),
+        },
+    )
     VoteService.vote(s1, "u1", "like")
     VoteService.vote(s2, "u2", "dislike")
     next_song = QueueService.get_next_song(room, queue)


### PR DESCRIPTION
## Summary
- Replace deprecated `datetime.utcnow()` usage with timezone-aware `datetime.now(timezone.utc)` across services and models
- Update tests to use timezone-aware timestamps and adjust formatting

## Testing
- `make lint` (fails: E302, E501, etc. in existing files)
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c608a954b48327a35d6995df6a8981