### PR TITLE
Fix queue functionality and playback handling

### DIFF
--- a/partyqueue/models/songs.py
+++ b/partyqueue/models/songs.py
@@ -34,8 +34,12 @@ def insert_song(
 
 
 def get_queue(coll, room_id: str) -> list[dict]:
-    return list(
-        coll.find(
-            {"room_id": room_id, "played": False, "removed_by_host": False}
-        )
+    songs = list(coll.find({"room_id": room_id}))
+    return sorted(
+        [
+            s
+            for s in songs
+            if not s.get("played") and not s.get("removed_by_host")
+        ],
+        key=lambda s: (-s.get("score", 0), s["added_at"]),
     )

--- a/partyqueue/services/queue_service.py
+++ b/partyqueue/services/queue_service.py
@@ -17,7 +17,7 @@ class QueueService:
                 and not existing.get("removed_by_host")
                 and not existing.get("played")
             ):
-                return existing
+                return None
         song.setdefault("_id", ObjectId())
         song.setdefault("added_at", datetime.now(timezone.utc))
         song.setdefault("likes", [])
@@ -48,6 +48,13 @@ class QueueService:
 
     @staticmethod
     def get_next_song(room: dict, queue: List[dict]) -> dict | None:
+        current_id = room.get("current_song_id")
+        if current_id:
+            for s in queue:
+                if s.get("_id") == current_id:
+                    s["played"] = True
+                    break
+            room["current_song_id"] = None
         ordered = QueueService.order_queue(queue)
         if ordered and ordered[0].get("score", 0) >= 0:
             room["current_song_id"] = ordered[0]["_id"]

--- a/tests/test_queue_features.py
+++ b/tests/test_queue_features.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta, timezone
+import os, sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from partyqueue.services.queue_service import QueueService
+from partyqueue.models import songs as songs_model
+
+
+def test_add_song_duplicate_returns_none():
+    room = {"banned_video_ids": [], "deleted_video_ids": []}
+    queue = []
+    first = QueueService.add_song(room, queue, {"video_id": "x", "title": "X"})
+    assert first is not None
+    assert QueueService.add_song(room, queue, {"video_id": "x", "title": "X"}) is None
+
+
+def test_get_next_song_advances_and_marks_previous():
+    room = {
+        "banned_video_ids": [],
+        "deleted_video_ids": [],
+        "current_song_id": None,
+    }
+    queue = []
+    s1 = QueueService.add_song(room, queue, {"video_id": "a", "title": "A"})
+    s2 = QueueService.add_song(room, queue, {"video_id": "b", "title": "B"})
+    first = QueueService.get_next_song(room, queue)
+    assert first["_id"] == s1["_id"]
+    second = QueueService.get_next_song(room, queue)
+    assert second["_id"] == s2["_id"]
+    assert s1["played"] is True
+
+
+class FakeColl:
+    def __init__(self, songs):
+        self.songs = songs
+
+    def find(self, query):
+        def match(song):
+            for k, v in query.items():
+                if song.get(k) != v:
+                    return False
+            return True
+
+        return [s.copy() for s in self.songs if match(s)]
+
+
+def test_get_queue_handles_missing_flags_and_orders():
+    now = datetime.now(timezone.utc)
+    songs = [
+        {"_id": "1", "room_id": "r1", "title": "A", "added_at": now, "score": 0},
+        {
+            "_id": "2",
+            "room_id": "r1",
+            "title": "B",
+            "added_at": now + timedelta(seconds=1),
+            "score": 1,
+        },
+        {
+            "_id": "3",
+            "room_id": "r1",
+            "title": "C",
+            "added_at": now + timedelta(seconds=2),
+            "score": 0,
+            "removed_by_host": True,
+        },
+        {"_id": "4", "room_id": "r2", "title": "D", "added_at": now, "score": 5},
+    ]
+    coll = FakeColl(songs)
+    queue = songs_model.get_queue(coll, "r1")
+    assert [s["_id"] for s in queue] == ["2", "1"]


### PR DESCRIPTION
## Summary
- return `None` when attempting to add a duplicate song to the queue
- advance playback by marking the previous song as played before selecting the next song
- ensure queue retrieval includes songs missing status flags and orders them correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60eb1b5f0832788efa50b9c426c50