### PR TITLE
Add SocketIO event support for real-time queue

### DIFF
--- a/partyqueue/app.py
+++ b/partyqueue/app.py
@@ -1,9 +1,13 @@
-from flask import Flask
-from .config import Config
-from .extensions import mongo, login_manager
-from .routes.auth import auth_bp
-from .routes.rooms import rooms_bp
-from .routes.api import api_bp
+import eventlet
+
+eventlet.monkey_patch()
+
+from flask import Flask  # noqa: E402
+from .config import Config  # noqa: E402
+from .extensions import mongo, login_manager, socketio  # noqa: E402
+from .routes.auth import auth_bp  # noqa: E402
+from .routes.rooms import rooms_bp  # noqa: E402
+from .routes.api import api_bp  # noqa: E402
 
 
 def create_app(config_object: type[Config] | None = None) -> Flask:
@@ -13,10 +17,13 @@ def create_app(config_object: type[Config] | None = None) -> Flask:
     mongo.init_app(app)
     mongo.db.users.create_index("username", unique=True)
     login_manager.init_app(app)
+    socketio.init_app(app, cors_allowed_origins="*")
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(rooms_bp)
     app.register_blueprint(api_bp, url_prefix="/api")
+
+    from . import sockets  # noqa: F401
 
     return app
 
@@ -25,4 +32,4 @@ app = create_app()
 
 
 if __name__ == "__main__":
-    app.run()
+    socketio.run(app)

--- a/partyqueue/extensions.py
+++ b/partyqueue/extensions.py
@@ -1,5 +1,7 @@
 from flask_pymongo import PyMongo
 from flask_login import LoginManager
+from flask_socketio import SocketIO
 
 mongo = PyMongo()
 login_manager = LoginManager()
+socketio = SocketIO(async_mode="eventlet")

--- a/partyqueue/sockets.py
+++ b/partyqueue/sockets.py
@@ -1,0 +1,99 @@
+from flask import request
+from flask_socketio import join_room
+from flask_login import current_user
+
+from .extensions import socketio, mongo
+from .models import SONGS_COLL, ROOMS_COLL
+from .services.queue_service import QueueService
+from .services.vote_service import VoteService
+
+
+def _emit_queue(room_id: str) -> None:
+    queue = list(mongo.db[SONGS_COLL].find({"room_id": room_id}))
+    ordered = QueueService.order_queue(queue)
+    for s in ordered:
+        s["_id"] = str(s["_id"])
+    socketio.emit(
+        "queue:updated", ordered, room=room_id, namespace="/room"
+    )
+
+
+@socketio.on("room:join", namespace="/room")
+def on_join(data):
+    room_id = data.get("room_id")
+    if not room_id:
+        return
+    join_room(room_id)
+    _emit_queue(room_id)
+    room = mongo.db[ROOMS_COLL].find_one({"_id": room_id})
+    if room and room.get("current_song_id"):
+        current = mongo.db[SONGS_COLL].find_one(
+            {"_id": room["current_song_id"]}
+        )
+        if current:
+            socketio.emit(
+                "player:play",
+                {"video_id": current["video_id"]},
+                room=request.sid,
+                namespace="/room",
+            )
+
+
+@socketio.on("queue:add", namespace="/room")
+def on_queue_add(data):
+    room_id = data.get("room_id")
+    video_id = data.get("video_id")
+    title = data.get("title")
+    if not room_id or not video_id or not title:
+        return
+    room = mongo.db[ROOMS_COLL].find_one({"_id": room_id})
+    if not room:
+        return
+    queue = list(mongo.db[SONGS_COLL].find({"room_id": room_id}))
+    song = {
+        "room_id": room_id,
+        "video_id": video_id,
+        "title": title,
+        "added_by_user_id": getattr(current_user, "id", None),
+        "added_by_display_name": getattr(current_user, "username", "Anon"),
+    }
+    new_song = QueueService.add_song(room, queue, song)
+    if not new_song:
+        return
+    mongo.db[SONGS_COLL].insert_one(new_song)
+    if not room.get("current_song_id"):
+        mongo.db[ROOMS_COLL].update_one(
+            {"_id": room_id}, {"$set": {"current_song_id": new_song["_id"]}}
+        )
+        socketio.emit(
+            "player:play",
+            {"video_id": video_id},
+            room=room_id,
+            namespace="/room",
+        )
+    _emit_queue(room_id)
+
+
+@socketio.on("queue:vote", namespace="/room")
+def on_queue_vote(data):
+    room_id = data.get("room_id")
+    song_id = data.get("song_id")
+    vote = data.get("vote")
+    if not room_id or not song_id or not vote:
+        return
+    song = mongo.db[SONGS_COLL].find_one({"_id": song_id})
+    if not song:
+        return
+    user_id = getattr(current_user, "id", request.sid)
+    VoteService.vote(song, user_id, vote)
+    mongo.db[SONGS_COLL].update_one(
+        {"_id": song_id},
+        {
+            "$set": {
+                "likes": song["likes"],
+                "dislikes": song["dislikes"],
+                "score": song["score"],
+            }
+        },
+    )
+    _emit_queue(room_id)

--- a/partyqueue/static/js/common.js
+++ b/partyqueue/static/js/common.js
@@ -1,1 +1,4 @@
 var socket = io('/room');
+if (window.roomId) {
+  socket.emit('room:join', { room_id: window.roomId });
+}

--- a/partyqueue/static/js/host_room.js
+++ b/partyqueue/static/js/host_room.js
@@ -1,0 +1,15 @@
+const queueEl = document.getElementById('queue');
+
+function renderQueue(queue) {
+  queueEl.innerHTML = '';
+  queue.forEach((s) => {
+    const row = document.createElement('div');
+    row.textContent = `${s.title} (score: ${s.score})`;
+    queueEl.appendChild(row);
+  });
+}
+
+if (window.roomId) {
+  fetch(`/api/rooms/${window.roomId}/queue`).then((r) => r.json()).then(renderQueue);
+  socket.on('queue:updated', renderQueue);
+}

--- a/partyqueue/templates/host_room.html
+++ b/partyqueue/templates/host_room.html
@@ -6,10 +6,11 @@
 <p class="mb-2">Listener code: {{ room.code_listener }}</p>
 <p class="mb-4">Suggestor code: {{ room.code_suggestor }}</p>
 <div id="player" class="my-4"></div>
-<ul id="queue"></ul>
+<div id="queue"></div>
 <script src="https://www.youtube.com/iframe_api"></script>
 <script>window.roomId = "{{ room._id }}";</script>
 <script src="/static/js/host_player.js" defer></script>
+<script src="/static/js/host_room.js" defer></script>
 {% else %}
 <h1 class="text-xl mb-4">Create Room</h1>
 <form method="post" class="flex flex-col gap-2">

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ black==23.7.0
 flake8==6.1.0
 Flask-PyMongo==2.3.0
 Werkzeug==2.3.0
+Flask-SocketIO==5.3.4
+eventlet==0.33.3


### PR DESCRIPTION
## Summary
- integrate Flask-SocketIO and eventlet
- broadcast queue updates and song playback events
- show host queue and join rooms on the client

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c611d739d0832794189549b85c2cd9