### PR TITLE
Ensure host player initialises and show queue voting

### DIFF
--- a/partyqueue/static/js/host_player.js
+++ b/partyqueue/static/js/host_player.js
@@ -1,10 +1,33 @@
 let player;
-function onYouTubeIframeAPIReady() {
-  player = new YT.Player('player');
-}
+let pendingVideoId = null;
 
-socket.on('player:play', data => {
+// Load the YouTube IFrame API dynamically so that the callback is
+// defined before the script requests it. This avoids situations where
+// the API loads before our handler is ready, leaving `player`
+// undefined and preventing videos from playing on the host's player.
+const tag = document.createElement('script');
+tag.src = 'https://www.youtube.com/iframe_api';
+document.head.appendChild(tag);
+
+window.onYouTubeIframeAPIReady = function () {
+  player = new YT.Player('player', {
+    events: {
+      onReady: () => {
+        if (pendingVideoId) {
+          player.loadVideoById(pendingVideoId);
+          pendingVideoId = null;
+        }
+      },
+    },
+  });
+};
+
+socket.on('player:play', (data) => {
   if (player) {
     player.loadVideoById(data.video_id);
+  } else {
+    // Player is not ready yet; remember the video id so it can be
+    // loaded once the API is initialised.
+    pendingVideoId = data.video_id;
   }
 });

--- a/partyqueue/static/js/host_room.js
+++ b/partyqueue/static/js/host_room.js
@@ -1,10 +1,31 @@
 const queueEl = document.getElementById('queue');
 
+// Render the queue with voting controls so the host can also
+// participate in prioritising songs.
 function renderQueue(queue) {
   queueEl.innerHTML = '';
   queue.forEach((s) => {
     const row = document.createElement('div');
-    row.textContent = `${s.title} (score: ${s.score})`;
+    row.className = 'flex items-center gap-2 mb-2';
+
+    const title = document.createElement('span');
+    title.textContent = `${s.title} (score: ${s.score})`;
+
+    const up = document.createElement('button');
+    up.textContent = '▲';
+    up.onclick = () => {
+      socket.emit('queue:vote', { room_id: window.roomId, song_id: s._id, vote: 'like' });
+    };
+
+    const down = document.createElement('button');
+    down.textContent = '▼';
+    down.onclick = () => {
+      socket.emit('queue:vote', { room_id: window.roomId, song_id: s._id, vote: 'dislike' });
+    };
+
+    row.appendChild(title);
+    row.appendChild(up);
+    row.appendChild(down);
     queueEl.appendChild(row);
   });
 }

--- a/partyqueue/templates/host_room.html
+++ b/partyqueue/templates/host_room.html
@@ -6,8 +6,7 @@
 <p class="mb-2">Listener code: {{ room.code_listener }}</p>
 <p class="mb-4">Suggestor code: {{ room.code_suggestor }}</p>
 <div id="player" class="my-4"></div>
-<div id="queue"></div>
-<script src="https://www.youtube.com/iframe_api"></script>
+<div id="queue" class="my-4"></div>
 <script>window.roomId = "{{ room._id }}";</script>
 <script src="/static/js/host_player.js" defer></script>
 <script src="/static/js/host_room.js" defer></script>


### PR DESCRIPTION
## Summary
- Dynamically load the YouTube IFrame API and queue pending videos so the host player plays newly added songs reliably
- Display the queue with voting controls for hosts to prioritise tracks
- Streamline host room template and expose queue container

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c613e5ff008327b39c25aef2b7f422