### PR TITLE
Use Socket.IO server for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: run dev format lint test
 
 run:
-	FLASK_APP=partyqueue.app flask run
+	flask --app partyqueue.app socketio run
 
 dev:
-	FLASK_APP=partyqueue.app FLASK_ENV=development flask run --reload
+	flask --app partyqueue.app --debug socketio run
 
 format:
 	black .

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ docker-compose up
 make dev
 ```
 
+This starts the Socket.IO server with eventlet. You can also run it manually:
+
+```bash
+flask --app partyqueue.app socketio run --debug
+```
+
 The app will be available at [http://localhost:5000](http://localhost:5000).
 
 ## Testing
@@ -112,7 +118,7 @@ make test
 ## Makefile Targets
 
 - `make run` – start server
-- `make dev` – development mode with reload
+- `make dev` – start server in debug mode with reload
 - `make format` – run black
 - `make lint` – run flake8
 - `make test` – run pytest


### PR DESCRIPTION
## Summary
- run dev server with `flask socketio run` so eventlet websocket transport works
- document socket.io server usage in README and Makefile targets

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_socketio')*


------
https://chatgpt.com/codex/tasks/task_e_68c616b363b48327ba0f9025027feef1