### PR TITLE
Replace socket.io with HTTP polling for queue updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PartyQueue
 
-PartyQueue is a Flask + MongoDB + Socket.IO web application for running collaborative karaoke or party music rooms. Users can search YouTube, add songs to a shared queue and vote in real time.
+PartyQueue is a Flask + MongoDB web application for running collaborative karaoke or party music rooms. Users can search YouTube, add songs to a shared queue and vote.
 
 ## Features
 
 - Email/password authentication with Flask-Login
 - Guest access via cookies
-- Realtime queue and chat powered by Socket.IO
+- Queue updates via simple HTTP polling
 - YouTube Data API search proxy
 - MongoDB for persistence
 

--- a/partyqueue/routes/api.py
+++ b/partyqueue/routes/api.py
@@ -2,8 +2,9 @@ from flask import Blueprint, request, jsonify
 from flask_login import login_required, current_user
 from ..services.youtube_service import search_videos
 from ..services.queue_service import QueueService
+from ..services.vote_service import VoteService
 from ..extensions import mongo
-from ..models import SONGS_COLL
+from ..models import SONGS_COLL, ROOMS_COLL
 
 api_bp = Blueprint("api", __name__)
 
@@ -23,3 +24,57 @@ def get_queue(room_id):
     for s in ordered:
         s["_id"] = str(s["_id"])
     return jsonify(ordered)
+
+
+@api_bp.post("/rooms/<room_id>/queue/add")
+def add_song(room_id):
+    data = request.get_json() or {}
+    video_id = data.get("video_id")
+    title = data.get("title")
+    user_id = (
+        current_user.id
+        if current_user.is_authenticated
+        else request.cookies.get("guest_id")
+    )
+    if not all([video_id, title, user_id]):
+        return jsonify({"error": "missing fields"}), 400
+    room = mongo.db[ROOMS_COLL].find_one({"_id": room_id}) or {}
+    queue = list(mongo.db[SONGS_COLL].find({"room_id": room_id}))
+    song = {
+        "room_id": room_id,
+        "video_id": video_id,
+        "title": title,
+        "added_by": user_id,
+    }
+    added = QueueService.add_song(room, queue, song)
+    if added is song:
+        mongo.db[SONGS_COLL].insert_one(song)
+    return get_queue(room_id)
+
+
+@api_bp.post("/rooms/<room_id>/queue/<song_id>/vote")
+def vote_song(room_id, song_id):
+    data = request.get_json() or {}
+    vote = data.get("vote")
+    user_id = (
+        current_user.id
+        if current_user.is_authenticated
+        else request.cookies.get("guest_id")
+    )
+    if not all([vote, user_id]):
+        return jsonify({"error": "missing fields"}), 400
+    song = mongo.db[SONGS_COLL].find_one({"_id": song_id, "room_id": room_id})
+    if not song:
+        return jsonify({"error": "not found"}), 404
+    VoteService.vote(song, user_id, vote)
+    mongo.db[SONGS_COLL].update_one(
+        {"_id": song_id},
+        {
+            "$set": {
+                "likes": song["likes"],
+                "dislikes": song["dislikes"],
+                "score": song["score"],
+            }
+        },
+    )
+    return get_queue(room_id)

--- a/partyqueue/static/js/common.js
+++ b/partyqueue/static/js/common.js
@@ -1,1 +1,0 @@
-var socket = io('/room');

--- a/partyqueue/static/js/guest_room.js
+++ b/partyqueue/static/js/guest_room.js
@@ -11,12 +11,20 @@ function renderQueue(queue) {
     const up = document.createElement('button');
     up.textContent = '▲';
     up.onclick = () => {
-      socket.emit('queue:vote', { room_id: window.roomId, song_id: s._id, vote: 'like' });
+      fetch(`/api/rooms/${window.roomId}/queue/${s._id}/vote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vote: 'like' })
+      }).then(fetchQueue);
     };
     const down = document.createElement('button');
     down.textContent = '▼';
     down.onclick = () => {
-      socket.emit('queue:vote', { room_id: window.roomId, song_id: s._id, vote: 'dislike' });
+      fetch(`/api/rooms/${window.roomId}/queue/${s._id}/vote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vote: 'dislike' })
+      }).then(fetchQueue);
     };
     row.appendChild(title);
     row.appendChild(up);
@@ -25,9 +33,13 @@ function renderQueue(queue) {
   });
 }
 
-if (window.roomId) {
+function fetchQueue() {
   fetch(`/api/rooms/${window.roomId}/queue`).then((r) => r.json()).then(renderQueue);
-  socket.on('queue:updated', renderQueue);
+}
+
+if (window.roomId) {
+  fetchQueue();
+  setInterval(fetchQueue, 5000);
 }
 
 if (document.getElementById('search-input')) {
@@ -51,7 +63,11 @@ if (document.getElementById('search-input')) {
       const btn = document.createElement('button');
       btn.textContent = 'Add';
       btn.onclick = () => {
-        socket.emit('queue:add', { room_id: window.roomId, video_id: v.video_id, title: v.title });
+        fetch(`/api/rooms/${window.roomId}/queue/add`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ video_id: v.video_id, title: v.title })
+        }).then(fetchQueue);
       };
       item.appendChild(thumb);
       item.appendChild(title);

--- a/partyqueue/static/js/host_player.js
+++ b/partyqueue/static/js/host_player.js
@@ -1,10 +1,23 @@
 let player;
+let currentSongId = null;
+
 function onYouTubeIframeAPIReady() {
   player = new YT.Player('player');
 }
 
-socket.on('player:play', data => {
-  if (player) {
-    player.loadVideoById(data.video_id);
+async function checkQueue() {
+  if (!window.roomId) return;
+  const res = await fetch(`/api/rooms/${window.roomId}/queue`);
+  const queue = await res.json();
+  if (queue.length && queue[0]._id !== currentSongId) {
+    currentSongId = queue[0]._id;
+    if (player) {
+      player.loadVideoById(queue[0].video_id);
+    }
   }
-});
+}
+
+if (window.roomId) {
+  checkQueue();
+  setInterval(checkQueue, 5000);
+}

--- a/partyqueue/templates/base.html
+++ b/partyqueue/templates/base.html
@@ -2,10 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <script src="https://cdn.socket.io/4.6.1/socket.io.min.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/static/js/common.js" defer></script>
     <link rel="stylesheet" href="/static/css/main.css" />
     <title>{% block title %}PartyQueue{% endblock %}</title>
   </head>


### PR DESCRIPTION
## Summary
- remove socket.io script and related client code
- add REST endpoints for adding songs and voting
- poll the queue periodically from host and guest clients

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c61f6455a88327ba5532ee829d2b86