### PR TITLE
Enable host to manage and control song queue

### DIFF
--- a/partyqueue/static/js/guest_room.js
+++ b/partyqueue/static/js/guest_room.js
@@ -34,7 +34,9 @@ function renderQueue(queue) {
 }
 
 function fetchQueue() {
-  fetch(`/api/rooms/${window.roomId}/queue`).then((r) => r.json()).then(renderQueue);
+  fetch(`/api/rooms/${window.roomId}/queue`)
+    .then((r) => r.json())
+    .then((data) => renderQueue(data.queue));
 }
 
 if (window.roomId) {

--- a/partyqueue/static/js/host_player.js
+++ b/partyqueue/static/js/host_player.js
@@ -1,20 +1,55 @@
 let player;
 let currentSongId = null;
+const queueEl = document.getElementById('queue');
 
 function onYouTubeIframeAPIReady() {
   player = new YT.Player('player');
 }
 
+function renderQueue(data) {
+  const queue = data.queue;
+  queueEl.innerHTML = '';
+  queue.forEach((s) => {
+    const li = document.createElement('li');
+    li.className = 'mb-2';
+    const title = document.createElement('span');
+    title.textContent = `${s.title} (score: ${s.score})`;
+    const playBtn = document.createElement('button');
+    playBtn.textContent = 'Play';
+    playBtn.onclick = () => {
+      fetch(`/api/rooms/${window.roomId}/queue/${s._id}/play`, { method: 'POST' }).then(checkQueue);
+    };
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = 'Remove';
+    removeBtn.onclick = () => {
+      fetch(`/api/rooms/${window.roomId}/queue/${s._id}/remove`, { method: 'POST' }).then(checkQueue);
+    };
+    li.appendChild(title);
+    li.appendChild(playBtn);
+    li.appendChild(removeBtn);
+    queueEl.appendChild(li);
+  });
+
+  let nextSong = queue[0];
+  if (data.current_song_id) {
+    const found = queue.find((s) => s._id === data.current_song_id);
+    if (found) {
+      nextSong = found;
+    }
+  }
+  if (nextSong && nextSong._id !== currentSongId) {
+    currentSongId = nextSong._id;
+    if (player) {
+      player.loadVideoById(nextSong.video_id);
+    }
+  }
+}
+
 async function checkQueue() {
   if (!window.roomId) return;
   const res = await fetch(`/api/rooms/${window.roomId}/queue`);
-  const queue = await res.json();
-  if (queue.length && queue[0]._id !== currentSongId) {
-    currentSongId = queue[0]._id;
-    if (player) {
-      player.loadVideoById(queue[0].video_id);
-    }
-  }
+  const data = await res.json();
+  renderQueue(data);
 }
 
 if (window.roomId) {


### PR DESCRIPTION
## Summary
- Show full song queue to the host and allow them to choose the current track
- Add API endpoints so hosts can remove songs or play any song immediately
- Update guest and host scripts to consume new queue format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c626f44ff48327998889e04c2576dc