### PR TITLE
Auto-play next song when current video finishes

### DIFF
--- a/partyqueue/routes/api.py
+++ b/partyqueue/routes/api.py
@@ -2,8 +2,8 @@ from flask import Blueprint, request, jsonify
 from flask_login import login_required, current_user
 from ..services.youtube_service import search_videos
 from ..services.queue_service import QueueService
-from ..extensions import mongo
-from ..models import SONGS_COLL
+from ..extensions import mongo, socketio
+from ..models import SONGS_COLL, ROOMS_COLL
 
 api_bp = Blueprint("api", __name__)
 
@@ -23,3 +23,35 @@ def get_queue(room_id):
     for s in ordered:
         s["_id"] = str(s["_id"])
     return jsonify(ordered)
+
+
+@api_bp.post("/rooms/<room_id>/next")
+def advance_queue(room_id):
+    """Advance the room's queue and return the next song if available."""
+    room = mongo.db[ROOMS_COLL].find_one({"_id": room_id})
+    if not room:
+        return jsonify({"error": "room not found"}), 404
+
+    queue = list(mongo.db[SONGS_COLL].find({"room_id": room_id}))
+    next_song = QueueService.get_next_song(room, queue)
+
+    # Persist room state and mark played songs
+    mongo.db[ROOMS_COLL].update_one(
+        {"_id": room_id}, {"$set": {"current_song_id": room.get("current_song_id")}}
+    )
+    for s in queue:
+        if s.get("played"):
+            mongo.db[SONGS_COLL].update_one(
+                {"_id": s["_id"]}, {"$set": {"played": True}}
+            )
+
+    # Notify listeners that the queue changed
+    ordered = QueueService.order_queue(queue)
+    for s in ordered:
+        s["_id"] = str(s["_id"])
+    socketio.emit("queue:updated", ordered, room=room_id, namespace="/room")
+
+    if next_song:
+        next_song["_id"] = str(next_song["_id"])
+        return jsonify(next_song), 200
+    return jsonify({}), 204

--- a/partyqueue/static/js/host_player.js
+++ b/partyqueue/static/js/host_player.js
@@ -18,6 +18,17 @@ window.onYouTubeIframeAPIReady = function () {
           pendingVideoId = null;
         }
       },
+      onStateChange: (e) => {
+        if (e.data === YT.PlayerState.ENDED && window.roomId) {
+          fetch(`/api/rooms/${window.roomId}/next`, { method: 'POST' })
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+              if (data && data.video_id) {
+                player.loadVideoById(data.video_id);
+              }
+            });
+        }
+      },
     },
   });
 };

--- a/tests/test_next_api.py
+++ b/tests/test_next_api.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+
+from partyqueue.app import create_app
+from partyqueue.extensions import mongo, socketio
+from partyqueue.models import SONGS_COLL, ROOMS_COLL
+
+
+def test_advance_queue_endpoint(monkeypatch):
+    room_id = "r1"
+    now = datetime.now(timezone.utc)
+    songs_docs = [
+        {
+            "_id": "s1",
+            "room_id": room_id,
+            "video_id": "a",
+            "title": "A",
+            "added_at": now,
+            "likes": [],
+            "dislikes": [],
+            "score": 0,
+            "played": False,
+            "removed_by_host": False,
+        },
+        {
+            "_id": "s2",
+            "room_id": room_id,
+            "video_id": "b",
+            "title": "B",
+            "added_at": now,
+            "likes": [],
+            "dislikes": [],
+            "score": 0,
+            "played": False,
+            "removed_by_host": False,
+        },
+    ]
+    room_doc = {
+        "_id": room_id,
+        "current_song_id": None,
+        "banned_video_ids": [],
+        "deleted_video_ids": [],
+    }
+
+    class SongsColl:
+        def find(self, query):
+            return [s.copy() for s in songs_docs if s["room_id"] == query.get("room_id")]
+
+        def update_one(self, query, update):
+            for s in songs_docs:
+                if s["_id"] == query["_id"]:
+                    s.update(update["$set"])
+
+    class RoomsColl:
+        def find_one(self, query):
+            if query.get("_id") == room_doc["_id"]:
+                return room_doc
+            return None
+
+        def update_one(self, query, update):
+            if query.get("_id") == room_doc["_id"]:
+                room_doc.update(update["$set"])
+
+    dummy_db = {SONGS_COLL: SongsColl(), ROOMS_COLL: RoomsColl()}
+    monkeypatch.setattr(mongo, "db", dummy_db, raising=False)
+    monkeypatch.setattr(socketio, "emit", lambda *a, **k: None)
+
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.post(f"/api/rooms/{room_id}/next")
+    assert resp.status_code == 200
+    assert resp.get_json()["video_id"] == "a"
+    assert songs_docs[0]["played"] is True
+
+    resp = client.post(f"/api/rooms/{room_id}/next")
+    assert resp.status_code == 200
+    assert resp.get_json()["video_id"] == "b"
+    assert room_doc["current_song_id"] == "s2"


### PR DESCRIPTION
## Summary
- add `/api/rooms/<room_id>/next` endpoint to advance queue and broadcast updates
- host player calls the new endpoint when a video ends to load the next track automatically
- test endpoint behavior with mocked database collections

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_socketio'; No module named 'eventlet')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask-SocketIO==5.3.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c62b8462288327a0f4654fce01d364