### PR TITLE
Enable automatic playback of next song

### DIFF
--- a/partyqueue/static/js/host_player.js
+++ b/partyqueue/static/js/host_player.js
@@ -3,7 +3,19 @@ let currentSongId = null;
 const queueEl = document.getElementById('queue');
 
 function onYouTubeIframeAPIReady() {
-  player = new YT.Player('player');
+  player = new YT.Player('player', {
+    events: {
+      onStateChange: onPlayerStateChange,
+    },
+  });
+}
+
+function onPlayerStateChange(event) {
+  if (event.data === YT.PlayerState.ENDED) {
+    fetch(`/api/rooms/${window.roomId}/queue/next`, { method: 'POST' })
+      .then((r) => r.json())
+      .then(renderQueue);
+  }
 }
 
 function renderQueue(data) {

--- a/tests/test_queue_logic.py
+++ b/tests/test_queue_logic.py
@@ -74,3 +74,16 @@ def test_auto_advance():
     VoteService.vote(s1, "u5", "dislike")  # score -1
     next_song = QueueService.get_next_song(room, queue)
     assert next_song is None
+
+
+def test_skips_played_song():
+    room = {"banned_video_ids": [], "deleted_video_ids": [], "current_song_id": None}
+    queue = []
+    now = datetime.now(timezone.utc)
+    s1 = QueueService.add_song(room, queue, {"video_id": "a", "title": "A", "added_at": now})
+    s2 = QueueService.add_song(room, queue, {"video_id": "b", "title": "B", "added_at": now})
+    room["current_song_id"] = s1["_id"]
+    s1["played"] = True
+    next_song = QueueService.get_next_song(room, queue)
+    assert next_song["_id"] == s2["_id"]
+    assert room["current_song_id"] == s2["_id"]


### PR DESCRIPTION
## Summary
- Advance to the next song when the current video finishes
- Listen for YouTube player end events and trigger server advance
- Cover queue advancement logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c62d03eac08327b88c280278360324