### PR TITLE
Skip unavailable YouTube videos

### DIFF
--- a/partyqueue/static/js/host_player.js
+++ b/partyqueue/static/js/host_player.js
@@ -29,6 +29,19 @@ window.onYouTubeIframeAPIReady = function () {
             });
         }
       },
+      // If a video fails to play (e.g. removed or restricted),
+      // advance the queue so playback continues.
+      onError: () => {
+        if (window.roomId) {
+          fetch(`/api/rooms/${window.roomId}/next`, { method: 'POST' })
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+              if (data && data.video_id) {
+                player.loadVideoById(data.video_id);
+              }
+            });
+        }
+      },
     },
   });
 };


### PR DESCRIPTION
## Summary
- Continue playback by skipping to the next song when a queued YouTube video fails to load

## Testing
- `flake8 partyqueue tests` *(fails: F401 and E501 in existing code)*
- `pytest` *(fails: ModuleNotFoundError for Flask-SocketIO/eventlet)*


------
https://chatgpt.com/codex/tasks/task_e_68c630adb56c8327b7da8602ed2718c3