### PR TITLE
Add browser extension toggle for host playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ make test
 
 The `docker-compose.yml` file defines services for the Flask app and MongoDB. This is suitable for local development.
 
+## Browser Extension
+
+A simple Brave/Chrome extension is provided in the `extension` directory. It keeps the host room page pinned and plays queued songs in a dedicated YouTube tab. On the host room page, click **Use Extension Player** to let the extension handle playback instead of the embedded player.
+
+### Installation
+
+1. Ensure the BeatVote server is running.
+2. Update `extension/background.js` to set `ROOM_ID` (and `SERVER_URL` if needed).
+3. In Brave, open `brave://extensions`.
+4. Enable **Developer mode**.
+5. Click **Load unpacked** and select the `extension` folder.
+6. The host page will open in a pinned tab. Click **Use Extension Player** on that page and songs from the queue will play in a separate tab.
+
 ## Notes
 
 Playback uses the YouTube IFrame Player API and requires a user gesture on the host page to enable audio because of browser autoplay policies.

--- a/beatvote/templates/host_room.html
+++ b/beatvote/templates/host_room.html
@@ -5,6 +5,7 @@
 <h1 class="text-xl">Host Room: {{ room.name }}</h1>
 <p class="mb-2">Listener code: {{ room.code_listener }}</p>
 <p class="mb-4">Suggestor code: {{ room.code_suggestor }}</p>
+<button id="use-extension" class="bg-gray-200 text-sm p-2 mb-2">Use Extension Player</button>
 <div id="player" class="my-4"></div>
 <ul id="queue"></ul>
 <script src="https://www.youtube.com/iframe_api"></script>

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,72 @@
+const SERVER_URL = "http://localhost:5000"; // Change if your server runs elsewhere
+const ROOM_ID = "default"; // Replace with your room ID
+
+let playerTabId = null;
+
+function ensureHostTab() {
+  const hostPage = `${SERVER_URL}/rooms/${ROOM_ID}/host`;
+  chrome.tabs.query({ url: `${SERVER_URL}/*` }, (tabs) => {
+    const exists = tabs.some((t) => t.url === hostPage);
+    if (!exists) {
+      chrome.tabs.create({ url: hostPage, pinned: true });
+    }
+  });
+}
+
+async function playNext() {
+  try {
+    const res = await fetch(
+      `${SERVER_URL}/api/rooms/${ROOM_ID}/queue/next`,
+      { method: "POST" }
+    );
+    const data = await res.json();
+    const currentId = data.current_song_id;
+    if (!currentId) {
+      if (playerTabId != null) {
+        chrome.tabs.remove(playerTabId);
+        playerTabId = null;
+      }
+      return;
+    }
+    const current = data.queue.find((s) => s._id === currentId);
+    if (!current) {
+      return;
+    }
+    const url = `https://www.youtube.com/watch?v=${current.video_id}`;
+    if (playerTabId == null) {
+      chrome.tabs.create({ url }, (tab) => {
+        playerTabId = tab.id;
+      });
+    } else {
+      chrome.tabs.update(playerTabId, { url }, () => {
+        if (chrome.runtime.lastError) {
+          chrome.tabs.create({ url }, (tab) => {
+            playerTabId = tab.id;
+          });
+        }
+      });
+    }
+  } catch (e) {
+    console.error("Failed to play next song", e);
+  }
+}
+
+function init() {
+  ensureHostTab();
+  playNext();
+}
+
+chrome.runtime.onInstalled.addListener(init);
+chrome.runtime.onStartup.addListener(init);
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "video-ended" || msg.type === "use-extension") {
+    playNext();
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (tabId === playerTabId) {
+    playerTabId = null;
+  }
+});

--- a/extension/host.js
+++ b/extension/host.js
@@ -1,0 +1,11 @@
+function attach() {
+  const btn = document.getElementById('use-extension');
+  if (!btn) {
+    setTimeout(attach, 1000);
+    return;
+  }
+  btn.addEventListener('click', () => {
+    chrome.runtime.sendMessage({ type: 'use-extension' });
+  });
+}
+attach();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 3,
+  "name": "BeatVote Player",
+  "version": "1.0",
+  "description": "Keeps the BeatVote host tab open and plays songs in a separate YouTube tab.",
+  "permissions": ["tabs"],
+  "host_permissions": ["http://localhost:5000/*", "https://www.youtube.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.youtube.com/*"],
+      "js": ["player.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["http://localhost:5000/rooms/*/host"],
+      "js": ["host.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "BeatVote Player"
+  }
+}

--- a/extension/player.js
+++ b/extension/player.js
@@ -1,0 +1,11 @@
+function attach() {
+  const video = document.querySelector('video');
+  if (!video) {
+    setTimeout(attach, 1000);
+    return;
+  }
+  video.addEventListener('ended', () => {
+    chrome.runtime.sendMessage({ type: 'video-ended' });
+  });
+}
+attach();


### PR DESCRIPTION
## Summary
- add host room button to switch between built-in player and extension-driven playback
- ensure extension reuses a single YouTube tab and closes it when queue is empty
- document extension usage and toggle in README

## Testing
- `pytest`
- `make lint` *(fails: E501 line too long and other existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a593ecd08327ba490c5c22ca8468