### PR TITLE
Default to extension player and persist selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The `docker-compose.yml` file defines services for the Flask app and MongoDB. Th
 
 ## Browser Extension
 
-A simple Brave/Chrome extension is provided in the `extension` directory. It keeps the host room page pinned and plays queued songs in a dedicated YouTube tab. On the host room page, click **Use Extension Player** to let the extension handle playback instead of the embedded player.
+A simple Brave/Chrome extension is provided in the `extension` directory. It keeps the host room page pinned and plays queued songs in a dedicated YouTube tab. The extension player is enabled by default on the host page, but you can switch to the embedded player by clicking **Use Web Player**.
 
 ### Installation
 
@@ -132,7 +132,7 @@ A simple Brave/Chrome extension is provided in the `extension` directory. It kee
 3. Enable **Developer mode**.
 4. Click **Load unpacked** and select the `extension` folder.
 5. Click the extension icon and enter your room ID.
-6. The host page will open in a pinned tab. Click **Use Extension Player** on that page and songs from the queue will play in a separate tab.
+6. The host page will open in a pinned tab and songs from the queue will play in a separate tab. To use the embedded player instead, click **Use Web Player** on the host page.
 
 ## Notes
 

--- a/beatvote/static/js/host_player.js
+++ b/beatvote/static/js/host_player.js
@@ -1,31 +1,45 @@
 let player;
 let currentSongId = null;
 let currentVideoId = null;
-let useExtension = false;
 const queueEl = document.getElementById('queue');
 const toggleBtn = document.getElementById('use-extension');
+
+let useExtension = true;
+const storedPref = localStorage.getItem('useExtension');
+if (storedPref !== null) {
+  useExtension = storedPref === 'true';
+} else {
+  localStorage.setItem('useExtension', 'true');
+}
+
+function updatePlayerMode() {
+  if (!toggleBtn) return;
+  if (useExtension) {
+    toggleBtn.textContent = 'Use Web Player';
+    const playerEl = document.getElementById('player');
+    if (playerEl) playerEl.style.display = 'none';
+    if (player) {
+      try {
+        player.stopVideo();
+      } catch (e) {
+        // ignore
+      }
+    }
+  } else {
+    toggleBtn.textContent = 'Use Extension Player';
+    const playerEl = document.getElementById('player');
+    if (playerEl) playerEl.style.display = '';
+    checkQueue();
+  }
+}
 
 if (toggleBtn) {
   toggleBtn.addEventListener('click', () => {
     useExtension = !useExtension;
-    if (useExtension) {
-      toggleBtn.textContent = 'Use Web Player';
-      const playerEl = document.getElementById('player');
-      if (playerEl) playerEl.style.display = 'none';
-      if (player) {
-        try {
-          player.stopVideo();
-        } catch (e) {
-          // ignore
-        }
-      }
-    } else {
-      toggleBtn.textContent = 'Use Extension Player';
-      const playerEl = document.getElementById('player');
-      if (playerEl) playerEl.style.display = '';
-      checkQueue();
-    }
+    localStorage.setItem('useExtension', useExtension.toString());
+    updatePlayerMode();
   });
+  updatePlayerMode();
 }
 
 function onYouTubeIframeAPIReady() {


### PR DESCRIPTION
## Summary
- default to the extension player and store the preference in localStorage
- document that extension playback is the default and how to switch to the web player

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6bbb29c4c8327b6b43b24f9a04a6b