### PR TITLE
Fix extension playback for new suggestions

### DIFF
--- a/beatvote/static/js/host_player.js
+++ b/beatvote/static/js/host_player.js
@@ -112,6 +112,7 @@ async function checkQueue() {
   const res = await fetch(`/api/rooms/${window.roomId}/queue`);
   const data = await res.json();
   renderQueue(data);
+  window.dispatchEvent(new Event('queue-updated'));
 }
 
 if (window.roomId) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -69,13 +69,15 @@ chrome.runtime.onInstalled.addListener(init);
 chrome.runtime.onStartup.addListener(init);
 
 chrome.runtime.onMessage.addListener((msg, sender) => {
-  if (msg.type === "video-ended" || msg.type === "use-extension") {
-    if (msg.type === "video-ended" && sender.tab) {
+  if (msg.type === "video-ended") {
+    if (sender.tab) {
       chrome.tabs.remove(sender.tab.id);
       if (sender.tab.id === playerTabId) {
         playerTabId = null;
       }
     }
+    playNext();
+  } else if (msg.type === "use-extension" || msg.type === "queue-updated") {
     playNext();
   } else if (msg.type === 'room-updated') {
     chrome.storage.local.get('roomId', (res) => {

--- a/extension/host.js
+++ b/extension/host.js
@@ -1,3 +1,7 @@
+window.addEventListener('queue-updated', () => {
+  chrome.runtime.sendMessage({ type: 'queue-updated' });
+});
+
 function attach() {
   const btn = document.getElementById('use-extension');
   if (!btn) {


### PR DESCRIPTION
## Summary
- trigger extension player whenever the queue updates
- relay host queue changes to background player for immediate playback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6bf9b5ae48327afc77cfddbc710b4