### PR TITLE
Preserve player tab until video ends

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -38,12 +38,8 @@ async function ensurePlayback() {
       queue = data.queue;
     }
 
-    // No song to play, close existing player tab if present
+    // No song to play, leave existing player tab until current video ends
     if (!currentId) {
-      if (playerTabId != null) {
-        chrome.tabs.remove(playerTabId);
-        playerTabId = null;
-      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Prevent immediate closure of the YouTube player tab by removing premature cleanup logic.
- Keep player tab open until a `video-ended` message is received before advancing to the next song.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c5a96e1083278ddc2b93d735017e