### PR TITLE
Add host dashboard and branding updates

### DIFF
--- a/beatvote/routes/rooms.py
+++ b/beatvote/routes/rooms.py
@@ -16,10 +16,20 @@ def landing():
 @login_required
 def create():
     if request.method == "POST":
+        existing_room = mongo.db[ROOMS_COLL].find_one({"host_user_id": current_user.id})
+        if existing_room:
+            return redirect(url_for("rooms.host_dashboard"))
         name = request.form.get("name", "My Party")
-        room = room_model.create_room(mongo.db[ROOMS_COLL], name, current_user.id)
-        return redirect(url_for("rooms.host", room_id=room["_id"]))
-    return render_template("host_room.html")
+        room_model.create_room(mongo.db[ROOMS_COLL], name, current_user.id)
+        return redirect(url_for("rooms.host_dashboard"))
+    return redirect(url_for("rooms.host_dashboard"))
+
+
+@rooms_bp.route("/host")
+@login_required
+def host_dashboard():
+    room = mongo.db[ROOMS_COLL].find_one({"host_user_id": current_user.id})
+    return render_template("host_room.html", room=room)
 
 
 @rooms_bp.route("/<room_id>/host")

--- a/beatvote/templates/base.html
+++ b/beatvote/templates/base.html
@@ -5,12 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="/static/css/main.css" />
+    <link
+      rel="icon"
+      type="image/jpeg"
+      href="{{ url_for('static', filename='images/beatvote_favicon.jpg') }}"
+    />
     <title>{% block title %}BeatVote{% endblock %}</title>
   </head>
   <body class="bg-gray-100">
     <nav class="bg-white shadow p-4 mb-4">
       <div class="container mx-auto flex justify-between">
-        <a href="{{ url_for('rooms.landing') }}" class="font-bold">BeatVote</a>
+        <a href="{{ url_for('rooms.landing') }}" class="font-bold">
+          <img
+            src="{{ url_for('static', filename='images/beatvote_logo.jpg') }}"
+            alt="BeatVote logo"
+            class="h-8"
+          />
+        </a>
         <div>
           {% if current_user.is_authenticated %}
           <span class="mr-4">{{ current_user.username }}</span>

--- a/beatvote/templates/host_room.html
+++ b/beatvote/templates/host_room.html
@@ -13,7 +13,11 @@
 <script src="/static/js/host_player.js" defer></script>
 {% else %}
 <h1 class="text-xl mb-4">Create Room</h1>
-<form method="post" class="flex flex-col gap-2">
+<form
+  method="post"
+  action="{{ url_for('rooms.create') }}"
+  class="flex flex-col gap-2"
+>
   <input type="text" name="name" placeholder="Room Name" class="border p-2" />
   <button class="bg-blue-500 text-white p-2" type="submit">Create</button>
 </form>

--- a/beatvote/templates/landing_choose.html
+++ b/beatvote/templates/landing_choose.html
@@ -2,7 +2,7 @@
 {% block title %}BeatVote{% endblock %}
 {% block content %}
 <div class="flex flex-col gap-4">
-  <a href="{{ url_for('rooms.create') }}" class="bg-blue-600 text-white p-4 text-center">Host a Room</a>
+  <a href="{{ url_for('rooms.host_dashboard') }}" class="bg-blue-600 text-white p-4 text-center">Host a Room</a>
   <a href="{{ url_for('rooms.join_page') }}" class="bg-gray-600 text-white p-4 text-center">Join a Room</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show BeatVote logo and favicon across the site
- Add `/host` dashboard that displays the user's room and restricts each user to one room
- Update landing page to link to the new dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6c5fe063083279169c9fa15647aed