### PR TITLE
Unify button styling across templates

### DIFF
--- a/partyqueue/static/css/main.css
+++ b/partyqueue/static/css/main.css
@@ -1,1 +1,35 @@
 body { font-family: sans-serif; }
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.btn-primary {
+  background-color: #3b82f6;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background-color: #2563eb;
+}
+
+.btn-secondary {
+  background-color: #22c55e;
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  background-color: #16a34a;
+}
+
+.btn-link {
+  background-color: transparent;
+  color: #3b82f6;
+}
+
+.btn-link:hover {
+  color: #2563eb;
+}

--- a/partyqueue/templates/auth_login.html
+++ b/partyqueue/templates/auth_login.html
@@ -5,6 +5,6 @@
 <form method="post" class="flex flex-col gap-2">
   <input type="email" name="email" placeholder="Email" class="p-2 border" required />
   <input type="password" name="password" placeholder="Password" class="p-2 border" required />
-  <button class="bg-blue-500 text-white p-2" type="submit">Login</button>
+  <button class="btn btn-primary" type="submit">Login</button>
 </form>
 {% endblock %}

--- a/partyqueue/templates/auth_signup.html
+++ b/partyqueue/templates/auth_signup.html
@@ -6,6 +6,6 @@
   <input type="email" name="email" placeholder="Email" class="p-2 border" required />
   <input type="text" name="username" placeholder="Username" class="p-2 border" required />
   <input type="password" name="password" placeholder="Password" class="p-2 border" required />
-  <button class="bg-green-500 text-white p-2" type="submit">Create Account</button>
+  <button class="btn btn-secondary" type="submit">Create Account</button>
 </form>
 {% endblock %}

--- a/partyqueue/templates/base.html
+++ b/partyqueue/templates/base.html
@@ -17,7 +17,7 @@
           {% if current_user.is_authenticated %}
           <span class="mr-4">{{ current_user.username }}</span>
           <form action="{{ url_for('auth.logout') }}" method="post" class="inline">
-            <button type="submit" class="text-blue-600">Logout</button>
+            <button type="submit" class="btn btn-link">Logout</button>
           </form>
           {% else %}
           <a href="{{ url_for('auth.signup') }}" class="mr-4 text-blue-600">Sign up</a>

--- a/partyqueue/templates/host_room.html
+++ b/partyqueue/templates/host_room.html
@@ -14,7 +14,7 @@
 <h1 class="text-xl mb-4">Create Room</h1>
 <form method="post" class="flex flex-col gap-2">
   <input type="text" name="name" placeholder="Room Name" class="border p-2" />
-  <button class="bg-blue-500 text-white p-2" type="submit">Create</button>
+  <button class="btn btn-primary" type="submit">Create</button>
 </form>
 {% endif %}
 {% endblock %}

--- a/partyqueue/templates/join_room.html
+++ b/partyqueue/templates/join_room.html
@@ -7,6 +7,6 @@
 {% endif %}
 <form method="post" class="flex gap-2">
   <input type="text" name="code" placeholder="Enter Code" class="border p-2" />
-  <button class="bg-blue-500 text-white p-2" type="submit">Join</button>
+  <button class="btn btn-primary" type="submit">Join</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable `.btn` styles with primary, secondary, and link variants
- apply new button classes across login, signup, room, and navigation templates

## Testing
- `make lint` *(fails: partyqueue/routes/api.py:2:1 F401 'flask_login.current_user' imported but unused, ...)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e7182fd88327913e2a002f55ad48